### PR TITLE
Update .gitignore to ignore .pdf files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+## Ignore pdf files. Only include them manually in the Master branch. In all other branches compile the latex locally
+.pdf
+
 ## Core latex/pdflatex auxiliary files:
 *.aux
 *.lof


### PR DESCRIPTION
What do you think about this?

I added .pdf files to the gitignore. Then when we work on all these branches and only pass LaTeX code between branches and not .pdf files. When we merge to Master we can then generate a .pdf file and upload it manually using the browser. 

It will make the syncing faster but it requires that we are remember to update all .pdfs effected. What do you think?

Comment below and if both of you agree, then the second to agree and merge the PR.